### PR TITLE
Fix script

### DIFF
--- a/rename.ps1
+++ b/rename.ps1
@@ -35,7 +35,7 @@ Function RenameFile($fileName)
 
 Function RenameFilesInDir($dirName)
 {	
-	$files = Get-ChildItem $dirName *.*
+	$files = Get-ChildItem $dirName | where { $_.FullName.Contains($OldName)}
 	ForEach ($file in $files) 
 	{ 
 		if ($file.PSisContainer){


### PR DESCRIPTION
Problem : Incorrect files selection logic in "RenameFilesInDir" function of "rename.ps1" script 
Solution 

> `$files = Get-ChildItem $dirName *.*`

Was be replaced by

> $files = Get-ChildItem $dirName | where { $_.FullName.Contains($OldName)}